### PR TITLE
.deb multi-architecture build

### DIFF
--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Build .deb for atop ${{ env.ATOP_VERSION }} (amd64)
         run: |
           docker buildx build \
+            --no-cache \
             --platform linux/amd64 \
             --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
             --output type=local,dest=build-deb/amd64 \

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -35,6 +35,14 @@ jobs:
             --output type=local,dest=build-deb/amd64 \
             -f Dockerfile.deb .
 
+      - name: Debug inhoud build-deb/amd64
+        run: |
+          find build-deb/amd64 -ls
+          ls -ld build-deb/amd64/lib/ssl/private || echo "Dir niet gevonden"
+
+      - name: Fix permissions (amd64)
+        run: sudo chmod -R a+rX build-deb/amd64
+
       - name: Upload .deb artifact (amd64)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -34,6 +34,9 @@ jobs:
             --output type=local,dest=build-deb/amd64 \
             -f Dockerfile.deb .
 
+      - name: Fix permissions (amd64)
+        run: sudo chmod -R a+rX build-deb/amd64
+
       - name: Upload .deb artifact (amd64)
         uses: actions/upload-artifact@v4
         with:
@@ -61,6 +64,9 @@ jobs:
             --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
             --output type=local,dest=build-deb/arm64 \
             -f Dockerfile.deb .
+
+      - name: Fix permissions (arm64)
+        run: sudo chmod -R a+rX build-deb/arm64
 
       - name: Upload .deb artifact (arm64)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -45,6 +45,12 @@ jobs:
             --output type=local,dest=build-deb/arm64 \
             -f Dockerfile.deb .
 
+      - name: Fix permissions (amd64)
+        run: sudo chmod -R a+rX build-deb/amd64
+
+      - name: Fix permissions (arm64)
+        run: sudo chmod -R a+rX build-deb/arm64
+
       - name: Upload .deb artifact (amd64)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -34,6 +34,9 @@ jobs:
             --output type=local,dest=build-deb/amd64 \
             -f Dockerfile.deb .
 
+      - name: Toon alle bestanden in build-deb/amd64
+        run: find build-deb/amd64 -type f -o -type d
+
       - name: Upload .deb artifact (amd64)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: atop-deb-amd64-${{ env.ATOP_VERSION }}
-          path: build-deb/amd64/
+          path: build-deb/amd64/*.deb
 
   # build-deb-arm64:
   #   name: 🏗️ Build .deb packages (arm64)

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-deb-amd64:
-    name: 🏗️ Build .deb packages (amd64)
+    name: 🏗️ Build .deb package for AMD64
     runs-on: ubuntu-latest
 
     steps:
@@ -41,7 +41,7 @@ jobs:
           path: build-deb/amd64/*.deb
 
   build-deb-arm64:
-    name: 🏗️ Build .deb packages (arm64)
+    name: 🏗️ Build .deb package for ARM64
     runs-on: ubuntu-latest
 
     steps:
@@ -62,9 +62,6 @@ jobs:
             --output type=local,dest=build-deb/arm64 \
             -f Dockerfile.deb .
 
-      - name: Fix permissions (arm64)
-        run: sudo chmod -R a+rX build-deb/arm64
-
       - name: Upload .deb artifact (arm64)
         uses: actions/upload-artifact@v4
         with:
@@ -74,6 +71,7 @@ jobs:
   build-rpm8:
     name: 🏗️ Building .rpm package for EL8
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -95,6 +93,7 @@ jobs:
   build-rpm9:
     name: 🏗️ Building .rpm package for EL9
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -34,84 +34,81 @@ jobs:
             --output type=local,dest=build-deb/amd64 \
             -f Dockerfile.deb .
 
-      - name: Fix permissions (amd64)
-        run: sudo chmod -R a+rX build-deb/amd64
-
       - name: Upload .deb artifact (amd64)
         uses: actions/upload-artifact@v4
         with:
           name: atop-deb-amd64-${{ env.ATOP_VERSION }}
           path: build-deb/amd64/
 
-  build-deb-arm64:
-    name: 🏗️ Build .deb packages (arm64)
-    runs-on: ubuntu-latest
+  # build-deb-arm64:
+  #   name: 🏗️ Build .deb packages (arm64)
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
 
-      - name: Set up QEMU for cross-compilation
-        uses: docker/setup-qemu-action@v3
+  #     - name: Set up QEMU for cross-compilation
+  #       uses: docker/setup-qemu-action@v3
 
-      - name: Build .deb for atop ${{ env.ATOP_VERSION }} (arm64)
-        run: |
-          docker buildx build \
-            --platform linux/arm64 \
-            --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
-            --output type=local,dest=build-deb/arm64 \
-            -f Dockerfile.deb .
+  #     - name: Build .deb for atop ${{ env.ATOP_VERSION }} (arm64)
+  #       run: |
+  #         docker buildx build \
+  #           --platform linux/arm64 \
+  #           --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
+  #           --output type=local,dest=build-deb/arm64 \
+  #           -f Dockerfile.deb .
 
-      - name: Fix permissions (arm64)
-        run: sudo chmod -R a+rX build-deb/arm64
+  #     - name: Fix permissions (arm64)
+  #       run: sudo chmod -R a+rX build-deb/arm64
 
-      - name: Upload .deb artifact (arm64)
-        uses: actions/upload-artifact@v4
-        with:
-          name: atop-deb-arm64-${{ env.ATOP_VERSION }}
-          path: build-deb/arm64/
+  #     - name: Upload .deb artifact (arm64)
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: atop-deb-arm64-${{ env.ATOP_VERSION }}
+  #         path: build-deb/arm64/
 
-  build-rpm8:
-    name: 🏗️ Building .rpm package for EL8
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+  # build-rpm8:
+  #   name: 🏗️ Building .rpm package for EL8
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
 
-      - name: Build .rpm file for atop ${{ env.ATOP_VERSION }}
-        run: |
-          docker build --build-arg ATOP_VERSION=$ATOP_VERSION -f Dockerfile8.rpm -t atop-rpm8-builder .
-          container_id=$(docker create atop-rpm8-builder)
-          mkdir -p build-rpm
-          docker cp "$container_id":/build/. ./build-rpm
-          docker rm "$container_id"
+  #     - name: Build .rpm file for atop ${{ env.ATOP_VERSION }}
+  #       run: |
+  #         docker build --build-arg ATOP_VERSION=$ATOP_VERSION -f Dockerfile8.rpm -t atop-rpm8-builder .
+  #         container_id=$(docker create atop-rpm8-builder)
+  #         mkdir -p build-rpm
+  #         docker cp "$container_id":/build/. ./build-rpm
+  #         docker rm "$container_id"
 
-      - name: Upload .rpm artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: atop-rpm8-${{ env.ATOP_VERSION }}
-          path: build-rpm/
+  #     - name: Upload .rpm artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: atop-rpm8-${{ env.ATOP_VERSION }}
+  #         path: build-rpm/
 
-  build-rpm9:
-    name: 🏗️ Building .rpm package for EL9
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+  # build-rpm9:
+  #   name: 🏗️ Building .rpm package for EL9
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v4
 
-      - name: Build .rpm file for atop ${{ env.ATOP_VERSION }}
-        run: |
-          docker build --build-arg ATOP_VERSION=$ATOP_VERSION -f Dockerfile9.rpm -t atop-rpm9-builder .
-          container_id=$(docker create atop-rpm9-builder)
-          mkdir -p build-rpm
-          docker cp "$container_id":/build/. ./build-rpm
-          docker rm "$container_id"
+  #     - name: Build .rpm file for atop ${{ env.ATOP_VERSION }}
+  #       run: |
+  #         docker build --build-arg ATOP_VERSION=$ATOP_VERSION -f Dockerfile9.rpm -t atop-rpm9-builder .
+  #         container_id=$(docker create atop-rpm9-builder)
+  #         mkdir -p build-rpm
+  #         docker cp "$container_id":/build/. ./build-rpm
+  #         docker rm "$container_id"
 
-      - name: Upload .rpm artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: atop-rpm9-${{ env.ATOP_VERSION }}
-          path: build-rpm/
+  #     - name: Upload .rpm artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: atop-rpm9-${{ env.ATOP_VERSION }}
+  #         path: build-rpm/

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -34,9 +34,6 @@ jobs:
             --output type=local,dest=build-deb/amd64 \
             -f Dockerfile.deb .
 
-      - name: Toon alle bestanden in build-deb/amd64
-        run: find build-deb/amd64 -type f -o -type d
-
       - name: Upload .deb artifact (amd64)
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -12,8 +12,8 @@ env:
   ATOP_VERSION: ${{ github.event.inputs.atop_version }}
 
 jobs:
-  build-deb:
-    name: 🏗️ Build .deb packages (amd64 & arm64)
+  build-deb-amd64:
+    name: 🏗️ Build .deb packages (amd64)
     runs-on: ubuntu-latest
 
     steps:
@@ -26,36 +26,41 @@ jobs:
       - name: Set up QEMU for cross-compilation
         uses: docker/setup-qemu-action@v3
 
-      - name: Build .deb for atop ${{ env.ATOP_VERSION }} (amd64 & arm64)
+      - name: Build .deb for atop ${{ env.ATOP_VERSION }} (amd64)
         run: |
-          # Empty architecture directories
-          mkdir -p build-deb/amd64 build-deb/arm64
-
-          # Build amd64
           docker buildx build \
             --platform linux/amd64 \
             --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
             --output type=local,dest=build-deb/amd64 \
             -f Dockerfile.deb .
 
-          # Build arm64
-          docker buildx build \
-            --platform linux/arm64 \
-            --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
-            --output type=local,dest=build-deb/arm64 \
-            -f Dockerfile.deb .
-
-      - name: Fix permissions (amd64)
-        run: sudo chmod -R a+rX build-deb/amd64
-
-      - name: Fix permissions (arm64)
-        run: sudo chmod -R a+rX build-deb/arm64
-
       - name: Upload .deb artifact (amd64)
         uses: actions/upload-artifact@v4
         with:
           name: atop-deb-amd64-${{ env.ATOP_VERSION }}
           path: build-deb/amd64/
+
+  build-deb-arm64:
+    name: 🏗️ Build .deb packages (arm64)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up QEMU for cross-compilation
+        uses: docker/setup-qemu-action@v3
+
+      - name: Build .deb for atop ${{ env.ATOP_VERSION }} (arm64)
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
+            --output type=local,dest=build-deb/arm64 \
+            -f Dockerfile.deb .
 
       - name: Upload .deb artifact (arm64)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -29,19 +29,10 @@ jobs:
       - name: Build .deb for atop ${{ env.ATOP_VERSION }} (amd64)
         run: |
           docker buildx build \
-            --no-cache \
             --platform linux/amd64 \
             --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
             --output type=local,dest=build-deb/amd64 \
             -f Dockerfile.deb .
-
-      - name: Debug inhoud build-deb/amd64
-        run: |
-          find build-deb/amd64 -ls
-          ls -ld build-deb/amd64/lib/ssl/private || echo "Dir niet gevonden"
-
-      - name: Fix permissions (amd64)
-        run: sudo chmod -R a+rX build-deb/amd64
 
       - name: Upload .deb artifact (amd64)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -40,75 +40,75 @@ jobs:
           name: atop-deb-amd64-${{ env.ATOP_VERSION }}
           path: build-deb/amd64/*.deb
 
-  # build-deb-arm64:
-  #   name: 🏗️ Build .deb packages (arm64)
-  #   runs-on: ubuntu-latest
+  build-deb-arm64:
+    name: 🏗️ Build .deb packages (arm64)
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-  #     - name: Set up QEMU for cross-compilation
-  #       uses: docker/setup-qemu-action@v3
+      - name: Set up QEMU for cross-compilation
+        uses: docker/setup-qemu-action@v3
 
-  #     - name: Build .deb for atop ${{ env.ATOP_VERSION }} (arm64)
-  #       run: |
-  #         docker buildx build \
-  #           --platform linux/arm64 \
-  #           --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
-  #           --output type=local,dest=build-deb/arm64 \
-  #           -f Dockerfile.deb .
+      - name: Build .deb for atop ${{ env.ATOP_VERSION }} (arm64)
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
+            --output type=local,dest=build-deb/arm64 \
+            -f Dockerfile.deb .
 
-  #     - name: Fix permissions (arm64)
-  #       run: sudo chmod -R a+rX build-deb/arm64
+      - name: Fix permissions (arm64)
+        run: sudo chmod -R a+rX build-deb/arm64
 
-  #     - name: Upload .deb artifact (arm64)
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: atop-deb-arm64-${{ env.ATOP_VERSION }}
-  #         path: build-deb/arm64/
+      - name: Upload .deb artifact (arm64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: atop-deb-arm64-${{ env.ATOP_VERSION }}
+          path: build-deb/arm64/*.deb
 
-  # build-rpm8:
-  #   name: 🏗️ Building .rpm package for EL8
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
+  build-rpm8:
+    name: 🏗️ Building .rpm package for EL8
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-  #     - name: Build .rpm file for atop ${{ env.ATOP_VERSION }}
-  #       run: |
-  #         docker build --build-arg ATOP_VERSION=$ATOP_VERSION -f Dockerfile8.rpm -t atop-rpm8-builder .
-  #         container_id=$(docker create atop-rpm8-builder)
-  #         mkdir -p build-rpm
-  #         docker cp "$container_id":/build/. ./build-rpm
-  #         docker rm "$container_id"
+      - name: Build .rpm file for atop ${{ env.ATOP_VERSION }}
+        run: |
+          docker build --build-arg ATOP_VERSION=$ATOP_VERSION -f Dockerfile8.rpm -t atop-rpm8-builder .
+          container_id=$(docker create atop-rpm8-builder)
+          mkdir -p build-rpm
+          docker cp "$container_id":/build/. ./build-rpm
+          docker rm "$container_id"
 
-  #     - name: Upload .rpm artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: atop-rpm8-${{ env.ATOP_VERSION }}
-  #         path: build-rpm/
+      - name: Upload .rpm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: atop-rpm8-${{ env.ATOP_VERSION }}
+          path: build-rpm/
 
-  # build-rpm9:
-  #   name: 🏗️ Building .rpm package for EL9
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
+  build-rpm9:
+    name: 🏗️ Building .rpm package for EL9
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-  #     - name: Build .rpm file for atop ${{ env.ATOP_VERSION }}
-  #       run: |
-  #         docker build --build-arg ATOP_VERSION=$ATOP_VERSION -f Dockerfile9.rpm -t atop-rpm9-builder .
-  #         container_id=$(docker create atop-rpm9-builder)
-  #         mkdir -p build-rpm
-  #         docker cp "$container_id":/build/. ./build-rpm
-  #         docker rm "$container_id"
+      - name: Build .rpm file for atop ${{ env.ATOP_VERSION }}
+        run: |
+          docker build --build-arg ATOP_VERSION=$ATOP_VERSION -f Dockerfile9.rpm -t atop-rpm9-builder .
+          container_id=$(docker create atop-rpm9-builder)
+          mkdir -p build-rpm
+          docker cp "$container_id":/build/. ./build-rpm
+          docker rm "$container_id"
 
-  #     - name: Upload .rpm artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: atop-rpm9-${{ env.ATOP_VERSION }}
-  #         path: build-rpm/
+      - name: Upload .rpm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: atop-rpm9-${{ env.ATOP_VERSION }}
+          path: build-rpm/

--- a/.github/workflows/build-atop.yml
+++ b/.github/workflows/build-atop.yml
@@ -13,25 +13,49 @@ env:
 
 jobs:
   build-deb:
-    name: 🏗️ Building .deb package
+    name: 🏗️ Build .deb packages (amd64 & arm64)
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build .deb file for atop ${{ env.ATOP_VERSION }}
-        run: |
-          docker build --build-arg ATOP_VERSION=$ATOP_VERSION -f Dockerfile.deb -t atop-deb-builder .
-          container_id=$(docker create atop-deb-builder)
-          mkdir -p build-deb
-          docker cp "$container_id":/build/. ./build-deb
-          docker rm "$container_id"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Upload .deb artifact
+      - name: Set up QEMU for cross-compilation
+        uses: docker/setup-qemu-action@v3
+
+      - name: Build .deb for atop ${{ env.ATOP_VERSION }} (amd64 & arm64)
+        run: |
+          # Empty architecture directories
+          mkdir -p build-deb/amd64 build-deb/arm64
+
+          # Build amd64
+          docker buildx build \
+            --platform linux/amd64 \
+            --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
+            --output type=local,dest=build-deb/amd64 \
+            -f Dockerfile.deb .
+
+          # Build arm64
+          docker buildx build \
+            --platform linux/arm64 \
+            --build-arg ATOP_VERSION=${{ env.ATOP_VERSION }} \
+            --output type=local,dest=build-deb/arm64 \
+            -f Dockerfile.deb .
+
+      - name: Upload .deb artifact (amd64)
         uses: actions/upload-artifact@v4
         with:
-          name: atop-deb-${{ env.ATOP_VERSION }}
-          path: build-deb/
+          name: atop-deb-amd64-${{ env.ATOP_VERSION }}
+          path: build-deb/amd64/
+
+      - name: Upload .deb artifact (arm64)
+        uses: actions/upload-artifact@v4
+        with:
+          name: atop-deb-arm64-${{ env.ATOP_VERSION }}
+          path: build-deb/arm64/
 
   build-rpm8:
     name: 🏗️ Building .rpm package for EL8

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -18,6 +18,8 @@ RUN make \
  && mkdir -p /build \
  && make install DESTDIR=/tmp/atop-installroot
 
+RUN rm -rf /tmp/atop-installroot/lib/ssl/private
+
 RUN mkdir -p /tmp/atop-installroot/DEBIAN
 RUN ARCH=$(dpkg --print-architecture) && \
     cat <<EOF > /tmp/atop-installroot/DEBIAN/control

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -3,6 +3,7 @@ FROM debian:12
 ARG ATOP_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Amsterdam
+ENV ARCH=$(dpkg --print-architecture)
 
 RUN apt update && apt install -y \
     build-essential wget pkg-config git make zlib1g-dev \
@@ -19,18 +20,20 @@ RUN make \
  && make install DESTDIR=/tmp/atop-installroot
 
 RUN mkdir -p /tmp/atop-installroot/DEBIAN
-RUN cat > /tmp/atop-installroot/DEBIAN/control <<EOF
+RUN ARCH=$(dpkg --print-architecture) && \
+    cat <<EOF > /tmp/atop-installroot/DEBIAN/control
 Package: atop
 Version: ${ATOP_VERSION}
 Section: admin
 Priority: optional
-Architecture: amd64
+Architecture: $ARCH
 Maintainer: Gerlof Langeveld
 Homepage: https://www.atoptool.nl
 Description: Advanced interactive system process monitor
-Depends: libc6, zlib1g, libncurses6, libglib2.0-0
+Depends: libc6, zlib1g, libncursesw6, libglib2.0-0
 EOF
 
-RUN dpkg-deb --build /tmp/atop-installroot /build/atop_${ATOP_VERSION}_amd64.deb
+RUN ARCH=$(dpkg --print-architecture) && \
+    dpkg-deb --build /tmp/atop-installroot /build/atop_${ATOP_VERSION}_$ARCH.deb
 
 CMD ["/bin/bash"]

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -1,4 +1,4 @@
-FROM debian:12 as builder
+FROM debian:12 AS builder
 
 ARG ATOP_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
@@ -41,4 +41,4 @@ RUN ARCH=$(dpkg --print-architecture) && \
 CMD ["/bin/bash"]
 
 FROM scratch AS export
-COPY --from=builder /build /build
+COPY --from=builder /build /

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -10,16 +10,17 @@ RUN apt update && apt install -y \
 
 WORKDIR /usr/src
 RUN wget https://www.atoptool.nl/download/atop-${ATOP_VERSION}.tar.gz \
- && tar xzf atop-${ATOP_VERSION}.tar.gz
+    && tar xzf atop-${ATOP_VERSION}.tar.gz
 
 WORKDIR /usr/src/atop-${ATOP_VERSION}
 RUN make \
- && mkdir -p /tmp/atop-installroot \
- && mkdir -p /build \
- && make install DESTDIR=/tmp/atop-installroot
+    && mkdir -p /tmp/atop-installroot \
+    && mkdir -p /build \
+    && make install DESTDIR=/tmp/atop-installroot
 
 RUN rm -rf /tmp/atop-installroot/lib/ssl/private && \
-    chmod -R a+rX /tmp/atop-installroot
+    chmod -R a+rX /tmp/atop-installroot && \
+    ls -laR /tmp/atop-installroot/lib/ssl
 
 RUN mkdir -p /tmp/atop-installroot/DEBIAN
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -1,4 +1,4 @@
-FROM debian:12
+FROM debian:12 as builder
 
 ARG ATOP_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
@@ -39,3 +39,6 @@ RUN ARCH=$(dpkg --print-architecture) && \
     dpkg-deb --build /tmp/atop-installroot /build/atop_${ATOP_VERSION}_$ARCH.deb
 
 CMD ["/bin/bash"]
+
+FROM scratch AS export
+COPY --from=builder /build /build

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -18,7 +18,7 @@ RUN make \
     && mkdir -p /build \
     && make install DESTDIR=/tmp/atop-installroot
 
-RUN rm -rf /tmp/atop-installroot/lib/ssl/private && \
+RUN rm -rf /tmp/atop-installroot/lib/ssl && \
     chmod -R a+rX /tmp/atop-installroot
 
 RUN mkdir -p /tmp/atop-installroot/DEBIAN

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -19,8 +19,7 @@ RUN make \
     && make install DESTDIR=/tmp/atop-installroot
 
 RUN rm -rf /tmp/atop-installroot/lib/ssl/private && \
-    chmod -R a+rX /tmp/atop-installroot && \
-    ls -laR /tmp/atop-installroot/lib/ssl
+    chmod -R a+rX /tmp/atop-installroot
 
 RUN mkdir -p /tmp/atop-installroot/DEBIAN
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -18,7 +18,8 @@ RUN make \
  && mkdir -p /build \
  && make install DESTDIR=/tmp/atop-installroot
 
-RUN rm -rf /tmp/atop-installroot/lib/ssl/private
+RUN rm -rf /tmp/atop-installroot/lib/ssl/private && \
+    chmod -R a+rX /tmp/atop-installroot
 
 RUN mkdir -p /tmp/atop-installroot/DEBIAN
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/Dockerfile.deb
+++ b/Dockerfile.deb
@@ -3,7 +3,6 @@ FROM debian:12
 ARG ATOP_VERSION
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Europe/Amsterdam
-ENV ARCH=$(dpkg --print-architecture)
 
 RUN apt update && apt install -y \
     build-essential wget pkg-config git make zlib1g-dev \


### PR DESCRIPTION
Add `arm64` build alongside the `amd64` build for the `.deb` version.  
Looking into `.rpm` multi-build.